### PR TITLE
Fix seed data

### DIFF
--- a/StudyFriend/Data/DbInitializer.cs
+++ b/StudyFriend/Data/DbInitializer.cs
@@ -1,25 +1,34 @@
-﻿using StudyFriend.Models;
+﻿using Microsoft.AspNetCore.Identity;
+using StudyFriend.Models;
+using System.Linq;
+using System.Security.Policy;
 
 namespace StudyFriend.Data
 {
     public static class DbInitializer
-    {
-        public static void Initialize(StudyFriendContext context)
+    
+    {        
+        public static async System.Threading.Tasks.Task InitializeAsync(
+            StudyFriendContext context, 
+            UserManager<ApplicationUser> userManager
+            )
         {
-            context.Database.EnsureCreated();
-            // If any Questions exist, don't reseed the DB
 
-            if (true)
+            context.Database.EnsureCreated();
+
+            // Don't seed db if test ApplicationUser exists
+            if (context.ApplicationUser.Any())
             {
                 return;
             }
 
-
-            
+            var user = new ApplicationUser { UserName = "test@test.com", Email = "test@test.com" };
+            _ = await userManager.CreateAsync(user, "P@ssw0rd1!");
+            context.SaveChanges();
 
             var topics = new Topic[]
             {
-                new Topic { Name = "Life"}
+                new Topic { Name = "JavaScript", UserId = user.Id}
             };
             foreach (Topic t in topics)
             {
@@ -30,7 +39,7 @@ namespace StudyFriend.Data
             
             var questions = new Question[]
             {
-                new Question{ Body="Will this even work?", TopicID=1 }
+                new Question{ Body="How do you stop event bubbling?", TopicID=topics[0].TopicID }
             };
             foreach (Question q in questions)
             {
@@ -40,7 +49,7 @@ namespace StudyFriend.Data
 
             var answers = new Answer[]
             {
-                new Answer { QuestionID = 1, Body ="Probably not" }
+                new Answer { Body="event.stopPropagation()", QuestionID = questions[0].QuestionID }
             };
             foreach (Answer a in answers)
             {

--- a/StudyFriend/Program.cs
+++ b/StudyFriend/Program.cs
@@ -4,13 +4,14 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using StudyFriend.Data;
-
+using Microsoft.AspNetCore.Identity;
+using StudyFriend.Models;
 
 namespace StudyFriend
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static async System.Threading.Tasks.Task Main(string[] args)
         {
             var host = CreateWebHostBuilder(args).Build();
 
@@ -20,8 +21,9 @@ namespace StudyFriend
 
                 try
                 {
+                    var userManager = services.GetRequiredService<UserManager<ApplicationUser>>();                    
                     var context = services.GetRequiredService<StudyFriendContext>();
-                    DbInitializer.Initialize(context);
+                    await DbInitializer.InitializeAsync(context, userManager);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Currently the application does not seed data. This was due to difficulties seeding the `ApplicationUser`, which requires the `UserManager` to create Identity users asynchronously.

This PR seeds an `ApplicationUser`, as well as all other models. The `Program` and `DbInitializer` classes now return an async Task (as oppose to void) to account for the asynchronous `userManager.CreateAsync()` call needed to create the user. 